### PR TITLE
Configure `main` and `types` properly for deploy

### DIFF
--- a/.github/workflows/deploy-published-releases.yaml
+++ b/.github/workflows/deploy-published-releases.yaml
@@ -36,6 +36,7 @@ jobs:
           mv package.json package-full.json
           cat package-full.json | \
             jq 'del(.dependencies) | del(.devDependencies) | del(.testDependencies) | del(.jest) | del(.scripts)' | \
+            jq '.main = "dist/index.js" | .types = "dist/index.d.ts"' | \
             jq ".version = \"${GITHUB_REF##*/}\"" > package.json
           cat package.json
 


### PR DESCRIPTION
## Summary
Prior to this change, the deployed package:
- did not set a custom `main` entrypoint, causing server imports to fail
- included the development `types` entry, pointing to an non-existing file

This change points `main` to `dist/index.js` and `types` to `dist/index.d.ts` during the deployment pipeline. The values used during development do not change.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings