### PR TITLE
Change exported values to differentiate using from NPM and from CDN

### DIFF
--- a/.github/workflows/deploy-published-releases.yaml
+++ b/.github/workflows/deploy-published-releases.yaml
@@ -30,7 +30,6 @@ jobs:
       - name: Build bundles
         run: |-
           npm run rollup
-          npm run rollup-min
 
           # Clear dependencies from package-lock.json
           mv package.json package-full.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -8304,9 +8304,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
-      "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.1.tgz",
+      "integrity": "sha512-W7KxyzeaQmZvUFbGj4+YFshhVrMBGSg2IbcYAjGWGvx8DHvJMclbTDMpffdxFUGPBHjIytk7KJUR/KUXstUGDw==",
       "dev": true,
       "requires": {
         "commander": "~2.20.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "test": "jest -c jest.config.js --coverage",
     "rollup": "rollup -c rollup.config.js",
-    "rollup-min": "rollup -c rollup.config.js --environment minify"
+    "rollup-min": "rollup -c rollup.min-config.js"
   },
   "dependencies": {
     "@croct-tech/sdk": "0.0.1-beta1"

--- a/rollup.min-config.js
+++ b/rollup.min-config.js
@@ -1,17 +1,21 @@
 import resolve from 'rollup-plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript2';
 import tempDir from 'temp-dir';
-import dts from 'rollup-plugin-dts';
+import {uglify} from 'rollup-plugin-uglify';
 import commonjs from 'rollup-plugin-commonjs';
 
 export default () => {
     return [
         {
-            input: 'src/index.ts',
+            input: 'src/plug.ts',
             output: {
-                file: 'build/index.js',
-                format: 'commonjs',
-                sourcemap: true,
+                file: 'build/plug.min.js',
+                name: 'croct',
+                format: 'iife',
+                sourcemap: false,
+            },
+            treeshake: {
+                propertyReadSideEffects: false,
             },
             plugins: [
                 resolve(),
@@ -20,12 +24,13 @@ export default () => {
                     cacheRoot: `${tempDir}/.rpt2_cache`,
                     useTsconfigDeclarationDir: true,
                 }),
+                uglify({
+                    compress: {
+                        unused: true,
+                        dead_code: true,
+                    },
+                }),
             ],
-        },
-        {
-            input: './build/declarations/index.d.ts',
-            output: [{file: 'build/index.d.ts', format: 'commonjs'}],
-            plugins: [dts({respectExternal: true})],
         },
     ];
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,128 +1,14 @@
 import {
     JsonValue,
-    SdkFacade,
     SdkFacadeConfiguration as Configuration,
     EvaluationFacadeOptions as EvaluationOptions,
     EvaluationErrorType,
     EvaluationError,
     ExpressionError,
-    SessionFacade,
-    TrackerFacade,
-    UserFacade,
     ExternalEvent,
     ExternalEventPayload,
     ExternalEventType,
 } from '@croct-tech/sdk';
-
-export interface Plug {
-    readonly tracker: TrackerFacade;
-    readonly user: UserFacade;
-    readonly session: SessionFacade;
-
-    plug(configuration: Configuration): void;
-
-    isAnonymous(): boolean;
-
-    getUserId(): string | null;
-
-    identify(userId: string): void;
-
-    anonymize(): void;
-
-    setToken(token: string): void;
-
-    unsetToken(): void;
-
-    track<T extends ExternalEventType>(type: T, payload: ExternalEventPayload<T>): Promise<ExternalEvent<T>>;
-
-    evaluate(expression: string, options?: EvaluationOptions): Promise<JsonValue>;
-
-    unplug(): Promise<void>;
-}
-
-class SingletonPlug implements Plug {
-    private facade?: SdkFacade;
-
-    public plug(configuration: Configuration): void {
-        if (this.facade !== undefined) {
-            const logger = this.facade.getLogger();
-
-            logger.info('Croct is already plugged in.');
-
-            return;
-        }
-
-        this.facade = SdkFacade.init(configuration);
-    }
-
-    private get instance(): SdkFacade {
-        if (this.facade === undefined) {
-            throw new Error('Croct is not plugged in.');
-        }
-
-        return this.facade;
-    }
-
-    public get tracker(): TrackerFacade {
-        return this.instance.tracker;
-    }
-
-    public get user(): UserFacade {
-        return this.instance.user;
-    }
-
-    public get session(): SessionFacade {
-        return this.instance.session;
-    }
-
-    public isAnonymous(): boolean {
-        return this.instance.context.isAnonymous();
-    }
-
-    public getUserId(): string | null {
-        return this.instance.context.getUser();
-    }
-
-    public identify(userId: string): void {
-        this.instance.identify(userId);
-    }
-
-    public anonymize(): void {
-        this.instance.anonymize();
-    }
-
-    public setToken(token: string): void {
-        this.instance.setToken(token);
-    }
-
-    public unsetToken(): void {
-        this.instance.unsetToken();
-    }
-
-    public track<T extends ExternalEventType>(type: T, payload: ExternalEventPayload<T>): Promise<ExternalEvent<T>> {
-        return this.instance.track(type, payload);
-    }
-
-    public evaluate(expression: string, options: EvaluationOptions = {}): Promise<JsonValue> {
-        return this.instance.evaluate(expression, options);
-    }
-
-    public async unplug(): Promise<void> {
-        if (this.facade === undefined) {
-            return;
-        }
-
-        const logger = this.instance.getLogger();
-
-        try {
-            await this.facade.close();
-        } finally {
-            delete this.facade;
-
-            logger.info('🔌 Croct has been unplugged.');
-        }
-    }
-}
 
 export {
     Configuration,
@@ -136,4 +22,4 @@ export {
     JsonValue,
 };
 
-export default new SingletonPlug();
+export {default as croct} from './plug';

--- a/src/plug.ts
+++ b/src/plug.ts
@@ -1,0 +1,124 @@
+import {
+    JsonValue,
+    SdkFacade,
+    SdkFacadeConfiguration as Configuration,
+    EvaluationFacadeOptions as EvaluationOptions,
+    SessionFacade,
+    TrackerFacade,
+    UserFacade,
+    ExternalEvent,
+    ExternalEventPayload,
+    ExternalEventType,
+} from '@croct-tech/sdk';
+
+export interface Plug {
+    readonly tracker: TrackerFacade;
+    readonly user: UserFacade;
+    readonly session: SessionFacade;
+
+    plug(configuration: Configuration): void;
+
+    isAnonymous(): boolean;
+
+    getUserId(): string | null;
+
+    identify(userId: string): void;
+
+    anonymize(): void;
+
+    setToken(token: string): void;
+
+    unsetToken(): void;
+
+    track<T extends ExternalEventType>(type: T, payload: ExternalEventPayload<T>): Promise<ExternalEvent<T>>;
+
+    evaluate(expression: string, options?: EvaluationOptions): Promise<JsonValue>;
+
+    unplug(): Promise<void>;
+}
+
+class GlobalPlug implements Plug {
+    private facade?: SdkFacade;
+
+    public plug(configuration: Configuration): void {
+        if (this.facade !== undefined) {
+            const logger = this.facade.getLogger();
+
+            logger.info('Croct is already plugged in.');
+
+            return;
+        }
+
+        this.facade = SdkFacade.init(configuration);
+    }
+
+    private get instance(): SdkFacade {
+        if (this.facade === undefined) {
+            throw new Error('Croct is not plugged in.');
+        }
+
+        return this.facade;
+    }
+
+    public get tracker(): TrackerFacade {
+        return this.instance.tracker;
+    }
+
+    public get user(): UserFacade {
+        return this.instance.user;
+    }
+
+    public get session(): SessionFacade {
+        return this.instance.session;
+    }
+
+    public isAnonymous(): boolean {
+        return this.instance.context.isAnonymous();
+    }
+
+    public getUserId(): string | null {
+        return this.instance.context.getUser();
+    }
+
+    public identify(userId: string): void {
+        this.instance.identify(userId);
+    }
+
+    public anonymize(): void {
+        this.instance.anonymize();
+    }
+
+    public setToken(token: string): void {
+        this.instance.setToken(token);
+    }
+
+    public unsetToken(): void {
+        this.instance.unsetToken();
+    }
+
+    public track<T extends ExternalEventType>(type: T, payload: ExternalEventPayload<T>): Promise<ExternalEvent<T>> {
+        return this.instance.track(type, payload);
+    }
+
+    public evaluate(expression: string, options: EvaluationOptions = {}): Promise<JsonValue> {
+        return this.instance.evaluate(expression, options);
+    }
+
+    public async unplug(): Promise<void> {
+        if (this.facade === undefined) {
+            return;
+        }
+
+        const logger = this.instance.getLogger();
+
+        try {
+            await this.facade.close();
+        } finally {
+            delete this.facade;
+
+            logger.info('🔌 Croct has been unplugged.');
+        }
+    }
+}
+
+export default new GlobalPlug();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import {SdkFacade, SdkFacadeConfiguration} from '@croct-tech/sdk';
-import croct from '../src/index';
+import {croct} from '../src/index';
 
 describe('The Croct plug', () => {
     const appId = '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a';


### PR DESCRIPTION
## Summary
Prior to this change, the default exported value, the global singleton, was exported along the error classes. This caused the global singleton plug to be available at `croct.default` at the browser instead of `croct`.

With this change, the javascript generated for the browser will export only the singleton plug as a global variable `croct` and the NPM package will export an object as module with the error classes and the singleton plug as its properties.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings