### PR TITLE
Expose `flushed` callback

### DIFF
--- a/src/plug.ts
+++ b/src/plug.ts
@@ -15,6 +15,7 @@ export interface Plug {
     readonly tracker: TrackerFacade;
     readonly user: UserFacade;
     readonly session: SessionFacade;
+    readonly flushed: Promise<void>;
 
     plug(configuration: Configuration): void;
 
@@ -50,6 +51,10 @@ class GlobalPlug implements Plug {
         }
 
         this.facade = SdkFacade.init(configuration);
+    }
+
+    public get flushed(): Promise<void> {
+        return this.tracker.flushed;
     }
 
     private get instance(): SdkFacade {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -41,6 +41,26 @@ describe('The Croct plug', () => {
         expect(initialize).toBeCalledTimes(1);
     });
 
+    test('should provide a callback that is called when the current pending events are flushed', async () => {
+        const config: SdkFacadeConfiguration = {appId: appId};
+
+        const sdkFacade = SdkFacade.init(config);
+
+        const flushed = jest.fn().mockResolvedValue(undefined);
+
+        Object.defineProperty(sdkFacade.tracker, 'flushed', {
+            get: flushed,
+        });
+
+        jest.spyOn(SdkFacade, 'init').mockReturnValue(sdkFacade);
+
+        croct.plug(config);
+
+        await expect(croct.flushed).resolves.toBeUndefined();
+
+        expect(flushed).toHaveBeenCalledTimes(1);
+    });
+
     test('should provide a tracker facade', () => {
         const config: SdkFacadeConfiguration = {appId: appId};
         const sdkFacade = SdkFacade.init(config);


### PR DESCRIPTION
## Summary
Expose `flushed` callback.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings