### PR TITLE
Log a warning when multiple plugins share the same name

### DIFF
--- a/src/globalPlug.ts
+++ b/src/globalPlug.ts
@@ -46,11 +46,21 @@ export class GlobalPlug implements Plug {
 
         const logger = this.instance.getLogger();
         const pending: Promise<void>[] = [];
+        const initialized: string[] = [];
 
         for (const plugin of plugins ?? []) {
             const pluginName = plugin.getName();
 
+            if (initialized.includes(pluginName)) {
+                logger.warn(
+                    `Multiple plugins registered with name "${pluginName}" `
+                    + 'which may cause unexpected errors.',
+                );
+            }
+
             logger.debug(`Initializing plugin "${pluginName}"...`);
+
+            initialized.push(pluginName);
 
             const controller = plugin.initialize({
                 tracker: sdk.tracker,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,14 @@
-import {SdkFacade, SdkFacadeConfiguration} from '@croct-tech/sdk';
+import {Logger, SdkFacade, SdkFacadeConfiguration} from '@croct-tech/sdk';
 import croct, {Configuration, Plugin, PluginController, PluginSdk} from '../src/index';
+
+function createLoggerMock(): Logger {
+    return {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    };
+}
 
 describe('The Croct plug', () => {
     const appId = '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a';
@@ -70,6 +79,31 @@ describe('The Croct plug', () => {
         expect(barPlugin.initialize).toBeCalled();
     });
 
+    test('should log a warn message if multiple plugins share the same name', async () => {
+        const fooPlugin: Plugin = {
+            getName(): string {
+                return 'foo';
+            },
+            initialize(): void {
+                // does nothing
+            },
+        };
+
+        const logger: Logger = createLoggerMock();
+
+        croct.plug({
+            appId: appId,
+            plugins: [fooPlugin, fooPlugin],
+            logger: logger,
+        });
+
+        await croct.plugged;
+
+        expect(logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining('Multiple plugins registered with name "foo" which may cause unexpected errors'),
+        );
+    });
+
     test('should handle failures enabling plugins', async () => {
         const fooController: PluginController = {
             enable: jest.fn().mockReturnValue(Promise.reject(new Error('Failure'))),
@@ -80,7 +114,7 @@ describe('The Croct plug', () => {
                 return 'foo';
             },
             initialize(): PluginController {
-                return fooController
+                return fooController;
             },
         };
 
@@ -107,7 +141,7 @@ describe('The Croct plug', () => {
             initialize(): PluginController {
                 return {
                     enable: fooEnable,
-                }
+                };
             },
         };
 
@@ -120,7 +154,7 @@ describe('The Croct plug', () => {
             initialize(): PluginController {
                 return {
                     enable: barEnable,
-                }
+                };
             },
         };
 
@@ -455,7 +489,7 @@ describe('The Croct plug', () => {
             initialize(): PluginController {
                 return {
                     disable: fooDisable,
-                }
+                };
             },
         };
 
@@ -468,7 +502,7 @@ describe('The Croct plug', () => {
             initialize(): PluginController {
                 return {
                     disable: barDisable,
-                }
+                };
             },
         };
 
@@ -529,7 +563,7 @@ describe('The Croct plug', () => {
                 return 'foo';
             },
             initialize(): PluginController {
-                return fooController
+                return fooController;
             },
         };
 


### PR DESCRIPTION
## Summary
Log a warning when multiple plugins share the same name

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings