### PR TITLE
Add support for plugins to self-register

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import {
     JsonValue,
 } from '@croct-tech/sdk';
 import {Plug, Configuration} from './plug';
-import {Plugin, PluginController, PluginSdk} from './plugin';
+import {Plugin, PluginFactory, PluginSdk} from './plugin';
 
 export {
     Sdk,
@@ -42,8 +42,8 @@ export {
     JsonValue,
     Plug,
     Configuration,
+    PluginFactory,
     Plugin,
-    PluginController,
     PluginSdk,
 };
 

--- a/src/plug.ts
+++ b/src/plug.ts
@@ -10,10 +10,13 @@ import {
     TrackerFacade,
     UserFacade,
 } from '@croct-tech/sdk';
-import {Plugin} from './plugin';
+
+interface PluginConfigurations {
+    [key: string]: any;
+}
 
 export type Configuration = SdkFacadeConfiguration & {
-    plugins?: Plugin[],
+    plugins?: PluginConfigurations,
 }
 
 export interface Plug {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -21,14 +21,17 @@ export interface PluginSdk {
     getBrowserStorage(...namespace: string[]): Storage;
 }
 
-export interface PluginController {
-    enable?(): Promise<void>|void;
+export interface PluginArguments<T = any> {
+    options: T;
+    sdk: PluginSdk;
+}
 
-    disable?(): Promise<void>|void;
+export interface PluginFactory<T = any> {
+    (args: PluginArguments<T>): Plugin;
 }
 
 export interface Plugin {
-    getName(): string;
+    enable(): Promise<void>|void;
 
-    initialize(sdk: PluginSdk): PluginController|void;
+    disable?(): Promise<void>|void;
 }

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -1,3 +1,3 @@
-import {GlobalPlug} from './globalPlug';
+import GlobalPlug from './globalPlug';
 
 export default new GlobalPlug();


### PR DESCRIPTION
## Summary
Add support for plugins to self-register.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings