### PR TITLE
Add support for testing boolean expressions

### DIFF
--- a/src/plug.ts
+++ b/src/plug.ts
@@ -282,8 +282,7 @@ export class GlobalPlug implements Plug {
 
     public test(expression: string, options: EvaluationOptions = {}): Promise<boolean> {
         return this.sdk.evaluate(expression, options)
-            .then(result => result === true)
-            .catch(() => false);
+            .then(result => result === true);
     }
 
     public async unplug(): Promise<void> {

--- a/src/plug.ts
+++ b/src/plug.ts
@@ -280,6 +280,12 @@ export class GlobalPlug implements Plug {
         return this.sdk.evaluate(expression, options);
     }
 
+    public test(expression: string, options: EvaluationOptions = {}): Promise<boolean> {
+        return this.sdk.evaluate(expression, options)
+            .then(result => result === true)
+            .catch(() => false);
+    }
+
     public async unplug(): Promise<void> {
         if (this.instance === undefined) {
             return;

--- a/src/plug.ts
+++ b/src/plug.ts
@@ -281,7 +281,7 @@ export class GlobalPlug implements Plug {
     }
 
     public test(expression: string, options: EvaluationOptions = {}): Promise<boolean> {
-        return this.sdk.evaluate(expression, options)
+        return this.evaluate(expression, options)
             .then(result => result === true);
     }
 

--- a/test/plug.test.ts
+++ b/test/plug.test.ts
@@ -659,10 +659,6 @@ describe('The Croct plug', () => {
         expect(evaluate).toBeCalledWith('user\'s name is "Carol"', {timeout: 5});
     });
 
-    test('should not allow to test expressions if unplugged', () => {
-        expect(() => croct.test('foo', {timeout: 5})).toThrow('Croct is not plugged in.');
-    });
-
     test('should wait for the plugins to disable before closing the SDK', async () => {
         let unloadFooPlugin: () => void = jest.fn();
         const fooDisable = jest.fn().mockImplementation(() => new Promise<void>(resolve => {

--- a/test/plug.test.ts
+++ b/test/plug.test.ts
@@ -602,6 +602,67 @@ describe('The Croct plug', () => {
         expect(() => croct.evaluate('foo', {timeout: 5})).toThrow('Croct is not plugged in.');
     });
 
+    test('should allow to test expressions', async () => {
+        const config: SdkFacadeConfiguration = {appId: APP_ID};
+        const sdkFacade = SdkFacade.init(config);
+
+        const initialize = jest.spyOn(SdkFacade, 'init').mockReturnValue(sdkFacade);
+
+        croct.plug(config);
+
+        expect(initialize).toBeCalledWith(config);
+
+        const evaluate = jest.spyOn(sdkFacade, 'evaluate').mockResolvedValue(true);
+
+        const promise = croct.test('user\'s name is "Carol"', {timeout: 5});
+
+        await expect(promise).resolves.toBe(true);
+
+        expect(evaluate).toBeCalledWith('user\'s name is "Carol"', {timeout: 5});
+    });
+
+    test('should test expressions assuming non-boolean results as false', async () => {
+        const config: SdkFacadeConfiguration = {appId: APP_ID};
+        const sdkFacade = SdkFacade.init(config);
+
+        const initialize = jest.spyOn(SdkFacade, 'init').mockReturnValue(sdkFacade);
+
+        croct.plug(config);
+
+        expect(initialize).toBeCalledWith(config);
+
+        const evaluate = jest.spyOn(sdkFacade, 'evaluate').mockResolvedValue('foo');
+
+        const promise = croct.test('user\'s name is "Carol"', {timeout: 5});
+
+        await expect(promise).resolves.toBe(false);
+
+        expect(evaluate).toBeCalledWith('user\'s name is "Carol"', {timeout: 5});
+    });
+
+    test('should test expressions assuming errors as false', async () => {
+        const config: SdkFacadeConfiguration = {appId: APP_ID};
+        const sdkFacade = SdkFacade.init(config);
+
+        const initialize = jest.spyOn(SdkFacade, 'init').mockReturnValue(sdkFacade);
+
+        croct.plug(config);
+
+        expect(initialize).toBeCalledWith(config);
+
+        const evaluate = jest.spyOn(sdkFacade, 'evaluate').mockRejectedValue(undefined);
+
+        const promise = croct.test('user\'s name is "Carol"', {timeout: 5});
+
+        await expect(promise).resolves.toBe(false);
+
+        expect(evaluate).toBeCalledWith('user\'s name is "Carol"', {timeout: 5});
+    });
+
+    test('should not allow to test expressions if unplugged', () => {
+        expect(() => croct.test('foo', {timeout: 5})).toThrow('Croct is not plugged in.');
+    });
+
     test('should wait for the plugins to disable before closing the SDK', async () => {
         let unloadFooPlugin: () => void = jest.fn();
         const fooDisable = jest.fn().mockImplementation(() => new Promise<void>(resolve => {

--- a/test/plug.test.ts
+++ b/test/plug.test.ts
@@ -640,7 +640,7 @@ describe('The Croct plug', () => {
         expect(evaluate).toBeCalledWith('user\'s name is "Carol"', {timeout: 5});
     });
 
-    test('should test expressions assuming errors as false', async () => {
+    test('should not test expressions assuming errors as false', async () => {
         const config: SdkFacadeConfiguration = {appId: APP_ID};
         const sdkFacade = SdkFacade.init(config);
 
@@ -654,7 +654,7 @@ describe('The Croct plug', () => {
 
         const promise = croct.test('user\'s name is "Carol"', {timeout: 5});
 
-        await expect(promise).resolves.toBe(false);
+        await expect(promise).rejects.toBeUndefined();
 
         expect(evaluate).toBeCalledWith('user\'s name is "Carol"', {timeout: 5});
     });


### PR DESCRIPTION
Evaluating boolean expressions is very useful for creating audiences since the goal is only to check if a user fulfills some requirements.

## Summary

Add support for testing boolean expressions.

Evaluating boolean expressions is very useful for creating audiences since the goal is only to check if a user fulfills some requirements.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings