### PR TITLE
Make the evaluate method generic to avoid casting on the call-site

### DIFF
--- a/src/plug.ts
+++ b/src/plug.ts
@@ -48,7 +48,7 @@ export interface Plug {
 
     track<T extends ExternalEventType>(type: T, payload: ExternalEventPayload<T>): Promise<ExternalEvent<T>>;
 
-    evaluate(expression: string, options?: EvaluationOptions): Promise<JsonValue>;
+    evaluate<T extends JsonValue>(expression: string, options?: EvaluationOptions): Promise<T>;
 
     unplug(): Promise<void>;
 }
@@ -281,8 +281,8 @@ export class GlobalPlug implements Plug {
         return this.sdk.tracker.track(type, payload);
     }
 
-    public evaluate(expression: string, options: EvaluationOptions = {}): Promise<JsonValue> {
-        return this.sdk.evaluator.evaluate(expression, options);
+    public evaluate<T extends JsonValue>(expression: string, options: EvaluationOptions = {}): Promise<T> {
+        return this.sdk.evaluator.evaluate(expression, options) as Promise<T>;
     }
 
     public test(expression: string, options: EvaluationOptions = {}): Promise<boolean> {


### PR DESCRIPTION
## Summary
Make the evaluate method generic to avoid casting on the call-site.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings