### PR TITLE
fix small typo on patch docs

### DIFF
--- a/docs/patch.md
+++ b/docs/patch.md
@@ -35,7 +35,7 @@ This reference documents all methods available in the Patch API and explains in 
 - [merge](#merge)
 - [increment](#increment)
 - [decrement](#decrement)
-- [save](#save
+- [save](#save)
 
 ### set
 


### PR DESCRIPTION
## Summary
Please include a summary of the change and which issue is addressed.

Fix a small typo on patch docs in the save index.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings