### PR TITLE
Rename fetch types and allow null payloads

### DIFF
--- a/src/eap.ts
+++ b/src/eap.ts
@@ -1,8 +1,8 @@
-import {JsonObject} from '@croct/sdk/json';
-import {ContentId, FetchResponse} from './fetch';
+import {SlotId, FetchResponse} from './fetch';
+import {NullableJsonObject} from './sdk/json';
 
 export interface EapFeatures {
-    fetch<P extends JsonObject, I extends ContentId = ContentId>(contentId: I): Promise<FetchResponse<I, P>>;
+    fetch<P extends NullableJsonObject, I extends SlotId = SlotId>(slotId: I): Promise<FetchResponse<I, P>>;
 }
 
 declare global {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,12 +1,12 @@
-import {JsonObject} from './sdk/json';
+import {NullableJsonObject} from './sdk/json';
 
-export interface ContentMap {
+export interface SlotMap {
 }
 
-export type ContentId = keyof ContentMap extends never ? string : keyof ContentMap;
+export type SlotId = keyof SlotMap extends never ? string : keyof SlotMap;
 
-export type ContentPayload<I extends ContentId> = I extends keyof ContentMap ? ContentMap[I] : JsonObject;
+export type SlotContent<I extends SlotId> = I extends keyof SlotMap ? SlotMap[I] : NullableJsonObject;
 
-export type FetchResponse<I extends ContentId, P extends JsonObject = JsonObject> = {
-    payload: ContentPayload<I> & P,
+export type FetchResponse<I extends SlotId, P extends NullableJsonObject = NullableJsonObject> = {
+    payload: SlotContent<I> & P,
 };

--- a/src/plug.ts
+++ b/src/plug.ts
@@ -1,5 +1,4 @@
 import {Logger} from '@croct/sdk/logging';
-import {JsonObject, JsonValue} from '@croct/sdk/json';
 import SessionFacade from '@croct/sdk/facade/sessionFacade';
 import UserFacade from '@croct/sdk/facade/userFacade';
 import TrackerFacade from '@croct/sdk/facade/trackerFacade';
@@ -19,7 +18,8 @@ import {Plugin, PluginArguments, PluginFactory} from './plugin';
 import {CDN_URL} from './constants';
 import {factory as playgroundPluginFactory} from './playground';
 import {EapFeatures} from './eap';
-import {ContentId, FetchResponse} from './fetch';
+import {SlotId, FetchResponse} from './fetch';
+import {NullableJsonObject, JsonValue} from './sdk/json';
 
 export interface PluginConfigurations {
     [key: string]: any;
@@ -309,8 +309,8 @@ export class GlobalPlug implements Plug {
     /**
      * This API is unstable and subject to change in future releases.
      */
-    public fetch<P extends JsonObject, I extends ContentId = ContentId>(contentId: I): Promise<FetchResponse<I, P>> {
-        return this.eap('fetch')(contentId);
+    public fetch<P extends NullableJsonObject, I extends SlotId = SlotId>(slotId: I): Promise<FetchResponse<I, P>> {
+        return this.eap('fetch')(slotId);
     }
 
     public async unplug(): Promise<void> {

--- a/src/sdk/json.ts
+++ b/src/sdk/json.ts
@@ -1,1 +1,4 @@
+import {JsonObject} from '@croct/sdk/json';
+
 export * from '@croct/sdk/json';
+export type NullableJsonObject = JsonObject | null;

--- a/test/plug.test.ts
+++ b/test/plug.test.ts
@@ -19,6 +19,8 @@ describe('The Croct plug', () => {
 
     beforeEach(() => {
         croct = new GlobalPlug();
+
+        delete window.croctEap;
     });
 
     afterEach(async () => {
@@ -807,20 +809,11 @@ describe('The Croct plug', () => {
         expect(close).toHaveBeenCalled();
     });
 
-    test('should fail to fetch a content if unplugged', () => {
+    test('should fail to fetch a slot content if unplugged', () => {
         expect(() => croct.fetch('foo')).toThrow('Croct is not plugged in.');
     });
 
-    test('should log a warning message when using EAP features', () => {
-        croct.plug({appId: APP_ID});
-
-        expect(() => croct.fetch('foo')).toThrow(
-            'The fetch feature is currently available only to accounts participating '
-            + 'in our Early-Access Program (EAP).',
-        );
-    });
-
-    test('should fail to fetch a content if the fetch method is undefined', () => {
+    test('should fail to fetch a slot content if the fetch method is undefined', () => {
         window.croctEap = {
             fetch: undefined,
         };
@@ -859,5 +852,14 @@ describe('The Croct plug', () => {
         expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining(
             'The fetch API is still unstable and subject to change in future releases.',
         ));
+    });
+
+    test('should log a warning message when using EAP features', () => {
+        croct.plug({appId: APP_ID});
+
+        expect(() => croct.fetch('foo')).toThrow(
+            'The fetch feature is currently available only to accounts participating '
+            + 'in our Early-Access Program (EAP).',
+        );
     });
 });


### PR DESCRIPTION
## Summary
Rename fetch types and allow null payloads.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings