### PR TITLE
Add an EAP init hook and bind EAP methods to the plug scope

### DIFF
--- a/src/eap.ts
+++ b/src/eap.ts
@@ -1,12 +1,17 @@
 import {SlotId, FetchResponse} from './fetch';
 import {NullableJsonObject} from './sdk/json';
+import {Plug} from './plug';
 
 export interface EapFeatures {
-    fetch<P extends NullableJsonObject, I extends SlotId = SlotId>(slotId: I): Promise<FetchResponse<I, P>>;
+    fetch<P extends NullableJsonObject, I extends SlotId = SlotId>(this: Plug, slotId: I): Promise<FetchResponse<I, P>>;
+}
+
+interface EapHooks extends EapFeatures{
+    initialize(this: Plug): void;
 }
 
 declare global {
     interface Window {
-        croctEap?: Partial<EapFeatures>;
+        croctEap?: Partial<EapHooks>;
     }
 }

--- a/src/plug.ts
+++ b/src/plug.ts
@@ -230,6 +230,12 @@ export class GlobalPlug implements Plug {
             );
         }
 
+        const initializeEap = window.croctEap?.initialize;
+
+        if (typeof initializeEap === 'function') {
+            initializeEap.call(this);
+        }
+
         Promise.all(pending).then(() => {
             this.initialize();
 
@@ -314,7 +320,7 @@ export class GlobalPlug implements Plug {
      * This API is unstable and subject to change in future releases.
      */
     public fetch<P extends NullableJsonObject, I extends SlotId = SlotId>(slotId: I): Promise<FetchResponse<I, P>> {
-        return this.eap('fetch')(slotId);
+        return this.eap('fetch').call(this, slotId);
     }
 
     public async unplug(): Promise<void> {
@@ -366,7 +372,7 @@ export class GlobalPlug implements Plug {
     private eap<T extends keyof EapFeatures>(feature: T): EapFeatures[T] {
         const logger = this.sdk.getLogger();
         const eap = window.croctEap;
-        const method = typeof eap === 'object' ? eap[feature] : undefined;
+        const method: EapFeatures[T] | undefined = typeof eap === 'object' ? eap[feature] : undefined;
 
         if (typeof method !== 'function') {
             throw new Error(
@@ -378,6 +384,6 @@ export class GlobalPlug implements Plug {
 
         logger.warn(`The ${feature} API is still unstable and subject to change in future releases.`);
 
-        return method.bind(eap);
+        return method;
     }
 }

--- a/test/plug.test.ts
+++ b/test/plug.test.ts
@@ -4,6 +4,7 @@ import {Plugin, PluginFactory} from '../src/plugin';
 import {GlobalPlug} from '../src/plug';
 import {CDN_URL} from '../src/constants';
 import {Token} from '../src/sdk/token';
+import {Plug} from '../build';
 
 jest.mock('../src/constants', () => {
     return {
@@ -117,6 +118,18 @@ describe('The Croct plug', () => {
         croct.plug(config);
 
         expect(initialize).toBeCalledWith(config);
+    });
+
+    test('should call the EAP initialization hook', () => {
+        window.croctEap = {
+            initialize: jest.fn().mockImplementation(function initialize(this: Plug) {
+                expect(this).toBe(croct);
+            }),
+        };
+
+        croct.plug({appId: APP_ID});
+
+        expect(window.croctEap.initialize).toBeCalled();
     });
 
     test('should log failures initializing plugins', () => {
@@ -856,7 +869,11 @@ describe('The Croct plug', () => {
         const response = Promise.resolve({payload: {title: 'Hello'}});
 
         window.croctEap = {
-            fetch: jest.fn().mockReturnValue(response),
+            fetch: jest.fn().mockImplementation(function fetch(this: Plug) {
+                expect(this).toBe(croct);
+
+                return response;
+            }),
         };
 
         const actualResponse = croct.fetch('foo');


### PR DESCRIPTION
## Summary
Add an EAP init hook and bind EAP methods to the plug scope.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings