### PR TITLE
Add property to check whether the plug has been initialized

### DIFF
--- a/src/plug.ts
+++ b/src/plug.ts
@@ -33,6 +33,7 @@ export interface Plug extends EapFeatures {
     readonly tracker: TrackerFacade;
     readonly user: UserFacade;
     readonly session: SessionFacade;
+    readonly initialized: boolean;
     readonly flushed: Promise<this>;
     readonly plugged: Promise<this>;
 
@@ -78,10 +79,10 @@ export class GlobalPlug implements Plug {
 
     private initialize: {(): void};
 
-    private initialized: Promise<void>;
+    private ready: Promise<void>;
 
     public constructor() {
-        this.initialized = new Promise(resolve => {
+        this.ready = new Promise(resolve => {
             this.initialize = resolve;
         });
     }
@@ -243,8 +244,12 @@ export class GlobalPlug implements Plug {
         });
     }
 
+    public get initialized(): boolean {
+        return this.instance !== undefined;
+    }
+
     public get plugged(): Promise<this> {
-        return this.initialized.then(() => this);
+        return this.ready.then(() => this);
     }
 
     public get flushed(): Promise<this> {
@@ -361,7 +366,7 @@ export class GlobalPlug implements Plug {
             delete this.instance;
 
             this.plugins = {};
-            this.initialized = new Promise(resolve => {
+            this.ready = new Promise(resolve => {
                 this.initialize = resolve;
             });
 

--- a/test/plug.test.ts
+++ b/test/plug.test.ts
@@ -1,10 +1,9 @@
 import {SdkFacade, Configuration as SdkFacadeConfiguration} from '@croct/sdk/facade/sdkFacade';
 import {Logger} from '../src/sdk';
 import {Plugin, PluginFactory} from '../src/plugin';
-import {GlobalPlug} from '../src/plug';
+import {GlobalPlug, Plug} from '../src/plug';
 import {CDN_URL} from '../src/constants';
 import {Token} from '../src/sdk/token';
-import {Plug} from '../build';
 
 jest.mock('../src/constants', () => {
     return {
@@ -333,6 +332,20 @@ describe('The Croct plug', () => {
 
         expect(initialize).toBeCalledWith(config);
         expect(initialize).toBeCalledTimes(1);
+    });
+
+    test('should determine whether it is initialized', async () => {
+        const config: SdkFacadeConfiguration = {appId: APP_ID};
+
+        expect(croct.initialized).toBe(false);
+
+        croct.plug(config);
+
+        expect(croct.initialized).toBe(true);
+
+        await croct.unplug();
+
+        expect(croct.initialized).toBe(false);
     });
 
     test('should provide a callback that is called when the plug is plugged in', async () => {


### PR DESCRIPTION
## Summary
Add property to check whether the plug has been initialized.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings