### PR TITLE
Adding custom.js script to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ To install the SDK as a script tag, add the following line to the `<head>` tag o
 
 ```html
 <script src="https://cdn.croct.io/js/v1/lib/plug.js?appId=<APP_ID>"></script>
+<script src="https://cdn.croct.io/js/v1/app/<APP_ID>/custom.js"></script>
 <script>croct.plug();</script>
 ```
 


### PR DESCRIPTION
## What has been done?

Our docs don't have the solution for the most common error: the absence of the custom.js. (I've promised to add some days ago, but I forgort :/).

> PS: I don't think we should explain in the docs what the custom.js do. At most we should say that the custom.js brings the slot payload, in my opinion.

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings