### PR TITLE
Fix event summary layout

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -61,7 +61,7 @@ There are several event types that you can record within the customer journey:
 | [`goalCompleted`](#goalcompleted)                       | Analytics     | No            | Records a goal completion.
 | [`interestShown`](#interestShown)                       | Miscellaneous | No            | Records a user has shown interest in something.
 | [`postViewed`](#postViewed)                             | Miscellaneous | No            | Records a post view.
-| ['linkOpened'](#linkOpened)                             | Miscellaneous | No            | This event records a link opening.
+| [`linkOpened`](#linkOpened)                             | Miscellaneous | No            | This event records a link opening.
 | [`sessionAttributesChanged`](#sessionattributeschanged) | Miscellaneous | Yes           | Records session's attributes changes.
 | [`nothingChanged`](#nothingchanged)                     | Miscellaneous | Yes           | Records a period of inactivity.
 | [`eventOccurred`](#eventOccurred)                       | Miscellaneous | No            | Records a custom event.


### PR DESCRIPTION
## Summary
Fix event summary layout because the 'linkOpened' was out of the standard.

### Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings