### PR TITLE
Lazily load SDK on fetch

### DIFF
--- a/src/plug.ts
+++ b/src/plug.ts
@@ -367,8 +367,6 @@ export class GlobalPlug implements Plug {
     }
 
     public get fetch(): Plug['fetch'] {
-        const logger = this.sdk.getLogger();
-
         return this.eap(
             'fetch',
             <C extends JsonObject, I extends VersionedSlotId = VersionedSlotId>(
@@ -376,6 +374,7 @@ export class GlobalPlug implements Plug {
                 options: FetchOptions = {},
             ): Promise<LegacyFetchResponse<I, C>> => {
                 const [id, version] = slotId.split('@') as [string, `${number}` | 'latest' | undefined];
+                const logger = this.sdk.getLogger();
 
                 return this.sdk
                     .contentFetcher


### PR DESCRIPTION
## Summary
Lazily load SDK on fetch to prevent errors on unit tests.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings