### PR TITLE
Improve URL update logic

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -39,10 +39,12 @@ export class PreviewPlugin implements Plugin {
         if (previewData !== null) {
             this.updateToken(previewData);
 
-            // Remove the token from the URL
-            url.searchParams.delete(PREVIEW_PARAMETER);
+            this.updateUrl();
 
-            window.history.replaceState({}, '', url.toString());
+            // Some frameworks (e.g. Next) may revert the URL change
+            // after the page is loaded, so ensure the token is removed
+            // from the URL after a short delay.
+            setTimeout(this.updateUrl, 500);
         }
 
         const token = this.tokenStore.getToken();
@@ -143,6 +145,16 @@ export class PreviewPlugin implements Plugin {
         });
 
         document.body.prepend(widget);
+    }
+
+    private updateUrl(): void {
+        const url = new URL(window.location.href);
+
+        if (url.searchParams.has(PREVIEW_PARAMETER)) {
+            url.searchParams.delete(PREVIEW_PARAMETER);
+
+            window.history.replaceState({}, '', url.toString());
+        }
     }
 
     private createWidget(url: string): HTMLIFrameElement {

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -113,9 +113,19 @@ describe('A Preview plugin', () => {
     it('should remove the preview parameter from the URL', () => {
         const plugin = new PreviewPlugin(configuration);
 
-        window.history.replaceState({}, 'Home page', `http://localhost?croct-preview=${token.toString()}`);
+        jest.useFakeTimers();
+
+        window.history.replaceState({}, 'Home page', `http://localhost/?croct-preview=${token.toString()}`);
 
         plugin.enable();
+
+        expect(window.location.href).toBe('http://localhost/');
+
+        window.history.replaceState({}, 'Home page', `http://localhost/?croct-preview=${token.toString()}`);
+
+        expect(window.location.href).toBe(`http://localhost/?croct-preview=${token.toString()}`);
+
+        jest.runAllTimers();
 
         expect(window.location.href).toBe('http://localhost/');
     });


### PR DESCRIPTION
## Summary
Some frameworks (e.g. Next) may revert the URL change after the page is loaded, so ensure the token is removed from the URL after a short delay.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings