### PR TITLE
Fix preview widget insertion trigger

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -144,7 +144,13 @@ export class PreviewPlugin implements Plugin {
             }
         });
 
-        document.body.prepend(widget);
+        const insert = (): void => document.body?.prepend(widget);
+
+        if (document.readyState === 'complete') {
+            insert();
+        } else {
+            window.addEventListener('DOMContentLoaded', insert);
+        }
     }
 
     private updateUrl(): void {

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -253,6 +253,30 @@ describe('A Preview plugin', () => {
         expect(src.searchParams.get('variant')).toBe(metadata.variantName);
     });
 
+    it('should insert the widget when the document is ready', () => {
+        Object.defineProperty(document, 'readyState', {
+            writable: true,
+            value: 'loading',
+        });
+
+        const plugin = new PreviewPlugin(configuration);
+
+        configuration.tokenStore.setToken(token);
+
+        plugin.enable();
+
+        expect(document.body.querySelector('iframe')).toBe(null);
+
+        Object.defineProperty(document, 'readyState', {
+            writable: true,
+            value: 'complete',
+        });
+
+        window.dispatchEvent(new Event('DOMContentLoaded'));
+
+        expect(document.body.querySelector('iframe')).not.toBe(null);
+    });
+
     it('should ignore messages from unknown origins', () => {
         const plugin = new PreviewPlugin(configuration);
 


### PR DESCRIPTION
## Summary
This PR prevents the widget from crashing when loaded before the document is ready (at this point, the body doesn't exist yet).

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings