### PR TITLE
Fix CompatibleSlotContent type

### DIFF
--- a/src/slot.ts
+++ b/src/slot.ts
@@ -22,8 +22,8 @@ export interface VersionedSlotMap extends LatestSlotVersionMap {
  */
 type Intersection<T, E> = T extends infer O ? O & E : never;
 
-type UnionContent = {
-    [K in ComponentVersionId]: Intersection<ComponentContent<K>, {_component: K | null}>;
+type UnionContent<T = null> = {
+    [K in ComponentVersionId]: Intersection<ComponentContent<K>, {_component: K | T}>;
 };
 
 type UnknownContent = UnionContent[ComponentVersionId] extends never
@@ -42,7 +42,7 @@ export type SlotVersionId<I extends SlotId = SlotId> = CanonicalVersionId<I, Ver
 
 export type VersionedSlotId<I extends SlotId = SlotId> = VersionedId<I, VersionedSlotMap>;
 
-export type CompatibleSlotContent<T extends ComponentVersionId = ComponentVersionId> = UnionContent[T];
+export type CompatibleSlotContent<T extends ComponentVersionId = ComponentVersionId> = UnionContent<never>[T];
 
 export type SlotContent<I extends VersionedSlotId = VersionedSlotId, C extends JsonObject = JsonObject> =
     JsonObject extends C ? (string extends I ? UnknownContent : VersionedContent<I>) : C;

--- a/test/slot.test.ts
+++ b/test/slot.test.ts
@@ -252,7 +252,7 @@ describe('Slot typing', () => {
 
         expect(() => compileCode(code)).not.toThrow();
 
-        expect(getTypeName(code)).toBe('Banner & {_component: "banner@1" | null;}');
+        expect(getTypeName(code)).toBe('Banner & {_component: "banner@1";}');
     });
 
     it('should export a CompatibleSlotContent type that resolves the slot content type for multiple components', () => {
@@ -268,9 +268,9 @@ describe('Slot typing', () => {
         expect(() => compileCode(code)).not.toThrow();
 
         expect(getTypeName(code)).toBe(
-            '(Banner & {_component: "banner@1" | null;})'
-            + ' | (HorizontalBanner & {_type: \'horizontal-banner\';} & {_component: "hybrid-banner@1" | null;})'
-            + ' | (VerticalBanner & {...;} & {_component: "hybrid-banner@1" | null;})',
+            '(Banner & {_component: "banner@1";})'
+            + ' | (HorizontalBanner & {_type: \'horizontal-banner\';} & {_component: "hybrid-banner@1";})'
+            + ' | (VerticalBanner & {_type: \'vertical-banner\';} & {_component: "hybrid-banner@1";})',
         );
     });
 


### PR DESCRIPTION
## Summary
The `_component` property of a `CompatibleSlotContent` is never null;

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings