### PR TITLE
Normalize empty preferred locale

### DIFF
--- a/src/plug.ts
+++ b/src/plug.ts
@@ -149,6 +149,10 @@ export class GlobalPlug implements Plug {
 
         const {plugins, test, ...sdkConfiguration} = configuration;
 
+        if (sdkConfiguration.defaultPreferredLocale === '') {
+            delete sdkConfiguration.defaultPreferredLocale;
+        }
+
         const sdk = SdkFacade.init({
             ...sdkConfiguration,
             appId: appId,

--- a/src/plug.ts
+++ b/src/plug.ts
@@ -383,15 +383,22 @@ export class GlobalPlug implements Plug {
     ): Promise<FetchResponse<I>> {
         const [id, version = 'latest'] = slotId.split('@') as [string, `${number}` | 'latest' | undefined];
         const logger = this.sdk.getLogger();
+        const preferredLocale = options.preferredLocale !== undefined && options.preferredLocale !== ''
+            ? options.preferredLocale
+            : undefined;
 
         return this.sdk
             .contentFetcher
-            .fetch<SlotContent<I>>(id, version === 'latest' ? options : {...options, version: version})
+            .fetch<SlotContent<I>>(id, {
+                ...options,
+                preferredLocale: preferredLocale,
+                version: version === 'latest' ? undefined : version,
+            })
             .catch(async error => {
                 logger.error(`Failed to fetch content for slot "${id}@${version}": ${formatCause(error)}`);
 
                 const resolvedFallback = fallback === undefined
-                    ? (await loadSlotContent(slotId, options.preferredLocale) as SlotContent<I>|null ?? undefined)
+                    ? (await loadSlotContent(slotId, preferredLocale) as SlotContent<I>|null ?? undefined)
                     : fallback;
 
                 if (resolvedFallback === undefined) {

--- a/test/api/fetchContent.test.ts
+++ b/test/api/fetchContent.test.ts
@@ -308,4 +308,25 @@ describe('fetchContent', () => {
 
         expect(logger.error).toHaveBeenCalledWith('Failed to fetch content for slot "test@latest": reason');
     });
+
+    it('should normalize an empty preferred locale to undefined', async () => {
+        const options: FetchOptions = {
+            apiKey: apiKey,
+            preferredLocale: '',
+        };
+
+        const error = new Error('Reason');
+
+        jest.mocked(mockFetch).mockRejectedValue(error);
+
+        jest.mocked(loadSlotContent).mockResolvedValue(null);
+
+        await expect(fetchContent('test', options)).rejects.toBe(error);
+
+        expect(loadSlotContent).toHaveBeenCalledWith('test', undefined);
+
+        expect(mockFetch).toHaveBeenCalledWith('test', {
+            preferredLocale: undefined,
+        });
+    });
 });

--- a/test/plug.test.ts
+++ b/test/plug.test.ts
@@ -157,6 +157,33 @@ describe('The Croct plug', () => {
         expect(initialize).toHaveBeenCalledWith(config);
     });
 
+    it('should normalize an empty default preferred locale to undefined', () => {
+        const config: SdkFacadeConfiguration = {
+            appId: APP_ID,
+            track: false,
+            debug: false,
+            test: true,
+            tokenScope: 'isolated',
+            userId: 'c4r0l',
+            eventMetadata: {
+                foo: 'bar',
+            },
+        };
+
+        const sdkFacade = SdkFacade.init(config);
+        const initialize = jest.spyOn(SdkFacade, 'init').mockReturnValue(sdkFacade);
+
+        croct.plug({
+            ...config,
+            defaultPreferredLocale: '',
+        });
+
+        expect(initialize).toHaveBeenCalledWith({
+            ...config,
+            defaultPreferredLocale: undefined,
+        });
+    });
+
     it.each([
         'test',
         'development',

--- a/test/plug.test.ts
+++ b/test/plug.test.ts
@@ -1055,6 +1055,45 @@ describe('The Croct plug', () => {
         );
     });
 
+    it('should normalize an empty locale to undefined', async () => {
+        const logger: Logger = {
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        };
+
+        const config: SdkFacadeConfiguration = {
+            appId: APP_ID,
+            logger: logger,
+        };
+
+        const sdkFacade = SdkFacade.init(config);
+
+        const initialize = jest.spyOn(SdkFacade, 'init').mockReturnValue(sdkFacade);
+
+        croct.plug(config);
+
+        expect(initialize).toHaveBeenCalledWith(expect.objectContaining(config));
+
+        const error = new Error('Reason');
+        const fetch = jest.spyOn(sdkFacade.contentFetcher, 'fetch').mockRejectedValue(error);
+
+        const slotId = 'test';
+
+        const options: FetchOptions = {preferredLocale: ''};
+
+        jest.mocked(loadSlotContent).mockResolvedValue(null);
+
+        await expect(croct.fetch(slotId, options)).rejects.toBe(error);
+
+        expect(fetch).toHaveBeenCalledWith(slotId, {
+            preferredLocale: undefined,
+        });
+
+        expect(loadSlotContent).toHaveBeenCalledWith(slotId, undefined);
+    });
+
     it('should extract the slot ID and version', async () => {
         const config: SdkFacadeConfiguration = {appId: APP_ID};
         const sdkFacade = SdkFacade.init(config);


### PR DESCRIPTION
## Summary
This PR normalizes preferred locales passed as empty strings to undefined, simplifying prop drilling. The Next.js SDK now exposes the getPreferredLocale function, which returns the preferred locale for a given route. Since the preferred locale may be unknown, this method could return either an empty string or null. However, returning null would require additional handling (e.g., using a null coalescing operator), as all consuming code expects either a string or undefined.

To avoid this, the method returns an empty string when no locale is specified. To ensure consistency across SDKs, this change is also being applied to the JavaScript SDK.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings