### PR TITLE
Avoid forwarding undefined options

### DIFF
--- a/src/api/fetchContent.ts
+++ b/src/api/fetchContent.ts
@@ -43,18 +43,25 @@ export function fetchContent<I extends VersionedSlotId, C extends JsonObject>(
     slotId: I,
     options?: FetchOptions<SlotContent<I, C>>,
 ): Promise<Omit<FetchResponse<I, C>, 'payload'>> {
-    const {apiKey, appId, fallback, baseEndpointUrl, logger, ...fetchOptions} = options ?? {};
+    const {
+        apiKey,
+        appId,
+        fallback,
+        baseEndpointUrl,
+        logger,
+        preferredLocale,
+        ...fetchOptions
+    } = options ?? {};
+
     const auth = {appId: appId, apiKey: apiKey};
     const [id, version = 'latest'] = slotId.split('@') as [I, `${number}` | 'latest' | undefined];
-    const preferredLocale = options?.preferredLocale !== undefined && options.preferredLocale !== ''
-        ? options.preferredLocale
-        : undefined;
+    const normalizedLocale = preferredLocale === '' ? undefined : preferredLocale;
 
     const promise = (new ContentFetcher({...auth, baseEndpointUrl: baseEndpointUrl}))
         .fetch<SlotContent<I, C>>(id, {
             ...fetchOptions,
-            preferredLocale: preferredLocale,
-            version: version === 'latest' ? undefined : version,
+            ...(normalizedLocale !== undefined ? {preferredLocale: normalizedLocale} : {}),
+            ...(version !== 'latest' ? {version: version} : {}),
         });
 
     return promise.catch(
@@ -67,7 +74,7 @@ export function fetchContent<I extends VersionedSlotId, C extends JsonObject>(
                 return {content: fallback};
             }
 
-            const staticContent = await loadSlotContent(id, preferredLocale);
+            const staticContent = await loadSlotContent(id, normalizedLocale);
 
             if (staticContent === null) {
                 throw error;

--- a/src/api/fetchContent.ts
+++ b/src/api/fetchContent.ts
@@ -49,7 +49,7 @@ export function fetchContent<I extends VersionedSlotId, C extends JsonObject>(
         fallback,
         baseEndpointUrl,
         logger,
-        preferredLocale,
+        preferredLocale = '',
         ...fetchOptions
     } = options ?? {};
 

--- a/test/api/fetchContent.test.ts
+++ b/test/api/fetchContent.test.ts
@@ -189,7 +189,7 @@ describe('fetchContent', () => {
             apiKey: options.apiKey,
         });
 
-        expect(mockFetch).toHaveBeenCalledWith(slotId, {
+        expect(jest.mocked(mockFetch).mock.calls[0][1]).toStrictEqual({
             timeout: options.timeout,
         });
     });

--- a/test/api/fetchContent.test.ts
+++ b/test/api/fetchContent.test.ts
@@ -325,8 +325,6 @@ describe('fetchContent', () => {
 
         expect(loadSlotContent).toHaveBeenCalledWith('test', undefined);
 
-        expect(mockFetch).toHaveBeenCalledWith('test', {
-            preferredLocale: undefined,
-        });
+        expect(jest.mocked(mockFetch).mock.calls[0][1]).toStrictEqual({});
     });
 });

--- a/test/plug.test.ts
+++ b/test/plug.test.ts
@@ -1175,7 +1175,7 @@ describe('The Croct plug', () => {
             content: content,
         });
 
-        expect(fetch).toHaveBeenLastCalledWith('foo', options);
+        expect(jest.mocked(fetch).mock.calls[0][1]).toStrictEqual(options);
     });
 
     it('should fail to fetch a slot content if unplugged', () => {

--- a/test/plug.test.ts
+++ b/test/plug.test.ts
@@ -1114,9 +1114,7 @@ describe('The Croct plug', () => {
 
         await expect(croct.fetch(slotId, options)).rejects.toBe(error);
 
-        expect(fetch).toHaveBeenCalledWith(slotId, {
-            preferredLocale: undefined,
-        });
+        expect(jest.mocked(fetch).mock.calls[0][1]).toStrictEqual({});
 
         expect(loadSlotContent).toHaveBeenCalledWith(slotId, undefined);
     });


### PR DESCRIPTION
## Summary
This PR is a hotfix for the previous one, as the content fetcher does not allow an undefined key to be passed, so it needs to be excluded from the forwarded options.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings