### PR TITLE
Add named export for global plug

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,9 @@ import {Configuration, Plug, GlobalPlug} from './plug';
 
 export type {Configuration, Plug};
 
+const plug = new GlobalPlug();
+
+export {plug};
+
 /* eslint-disable-next-line import/no-default-export -- Should be default export */
-export default new GlobalPlug();
+export default plug;


### PR DESCRIPTION
## Summary

When using a default export in the Plug React module, it leads to a double-wrapping issue in CommonJS (CJS) bundles. Specifically, importing the module results in an object like `{ default: { default: ... } }`, instead of the expected `{ default: ... }`. This behavior is due to how esbuild handles interoperability between ECMAScript Modules (ESM) and CJS, as detailed in [esbuild issue #2023](https://github.com/evanw/esbuild/issues/2023).

To resolve this, the pull request introduces a named export for the global Plug instance. 

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings