### PR TITLE
Fix empty constants in published package

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -6,15 +6,14 @@ on:
       - synchronize
       - opened
 
-env:
-  BASE_ENDPOINT: https://api.croct.io
-  MAX_QUERY_LENGTH: 500
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # This is required for resolving the latest release tag
+
       - uses: actions/setup-node@v6
         with:
           node-version: 23
@@ -24,7 +23,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: node_modules
-          key: node_modules-${{ hashFiles('**/package-lock.json') }}
+          key: node_modules-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
@@ -33,14 +32,10 @@ jobs:
       - name: Build package
         run: npm run build
 
-      - name: Prepare release
-        run: |-
-          cp LICENSE README.md build/
-          cd build
-          find . -type f -path '*/*\.js.map' -exec sed -i -e "s~../src~src~" {} +          
-          sed -i -e "s~<@version@>~0.0.0-dev~" constants.*
-          sed -i -e "s~<@baseEndpointUrl@>~${BASE_ENDPOINT}~" constants.*
-          sed -i -e "s~parseInt('<@maxQueryLength@>', 10)~${MAX_QUERY_LENGTH}~" constants.*
+      - name: Prepare preview
+        # The preview widget is deployed on release only, so the constants point
+        # to the latest released one.
+        run: node prepare-release.mjs "$(git describe --tags --abbrev=0 2>/dev/null || echo 0.0.0-dev)"
 
       - name: Publish preview
         run: |-

--- a/.github/workflows/deploy-release.yaml
+++ b/.github/workflows/deploy-release.yaml
@@ -5,30 +5,13 @@ on:
     types:
       - published
 
-env:
-  CDN_URL: https://cdn.croct.io/js/v1/lib/plug.js
-  PLAYGROUND_ORIGIN: https://play.croct.com
-  PLAYGROUND_CONNECT_URL: https://play.croct.com/connect.html
-  PREVIEW_WIDGET_ORIGIN: https://cdn.croct.io
-  PREVIEW_WIDGET_PATH: js/v1/lib/plug/widget-${{ github.ref_name }}.html
-  PREVIEW_WIDGET_URL: https://cdn.croct.io/js/v1/lib/plug/widget-${{ github.ref_name }}.html
-
 jobs:
   deploy:
     uses: croct-tech/shared-public-configs/.github/workflows/publish-public-npm-package.yml@master
     with:
-      prepare-script: >-
-        cp LICENSE README.md build/ &&
-        cd build &&
-        find . -type f -path '*/*\.js.map' -exec sed -i -e "s~../src~src~" {} + &&
-        tmp=$(mktemp) &&
-        jq --arg version "$GITHUB_REF_NAME" '.version = $version' package.json > "$tmp" &&
-        mv "$tmp" package.json &&
-        sed -i -e "s~<@cdnUrl@>~${CDN_URL}~" constants.* &&
-        sed -i -e "s~<@playgroundOrigin@>~${PLAYGROUND_ORIGIN}~" constants.* &&
-        sed -i -e "s~<@playgroundConnectUrl@>~${PLAYGROUND_CONNECT_URL}~" constants.* &&
-        sed -i -e "s~<@previewWidgetOrigin@>~${PREVIEW_WIDGET_ORIGIN}~" constants.* &&
-        sed -i -e "s~<@previewWidgetUrl@>~${PREVIEW_WIDGET_URL}~" constants.*
+      # The caller's `env` block is not propagated to reusable workflows, so the
+      # constants are resolved by the script itself, from `release-config.mjs`.
+      prepare-script: node prepare-release.mjs
 
   cdn:
     if: ${{ !github.event.release.prerelease }}
@@ -45,6 +28,9 @@ jobs:
           node-version: 23
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Resolve release constants
+        run: node release-config.mjs >> "$GITHUB_ENV"
 
       - name: Cache dependencies
         id: cache-dependencies
@@ -97,12 +83,16 @@ jobs:
         with:
           node-version: 23
 
+      - name: Resolve release constants
+        working-directory: .
+        run: node release-config.mjs >> "$GITHUB_ENV"
+
       - name: Cache dependencies
         id: cache-dependencies
         uses: actions/cache@v5
         with:
-          path: node_modules
-          key: node_modules-${{ hashFiles('package-lock.json') }}
+          path: preview/node_modules
+          key: preview_node_modules-${{ hashFiles('preview/package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'

--- a/prepare-release.mjs
+++ b/prepare-release.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import {getConstants, getVersion} from './release-config.mjs';
+
+const BUILD_DIR = path.resolve('build');
+const PACKAGE_JSON = path.join(BUILD_DIR, 'package.json');
+const ROOT_FILES = ['LICENSE', 'README.md'];
+const PLACEHOLDER_PATTERN = /<@(\w+)@>/g;
+const TEXT_FILE_PATTERN = /\.(?:js|cjs|mjs|ts|cts|mts|json|map)$/;
+
+function findFiles(dir, pattern, fileList = []) {
+    for (const file of fs.readdirSync(dir)) {
+        const filePath = path.join(dir, file);
+
+        if (fs.statSync(filePath).isDirectory()) {
+            findFiles(filePath, pattern, fileList);
+        } else if (pattern.test(file)) {
+            fileList.push(filePath);
+        }
+    }
+
+    return fileList;
+}
+
+function copyRootFiles() {
+    for (const file of ROOT_FILES) {
+        fs.copyFileSync(path.resolve(file), path.join(BUILD_DIR, file));
+    }
+
+    console.log(`✅ Copied ${ROOT_FILES.join(', ')}`);
+}
+
+function updateVersion(version) {
+    const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf-8'));
+
+    pkg.version = version;
+
+    fs.writeFileSync(PACKAGE_JSON, JSON.stringify(pkg, null, 2));
+
+    console.log(`✅ Set version to ${version}`);
+}
+
+function fixSourceMaps() {
+    const maps = findFiles(BUILD_DIR, /\.map$/);
+
+    for (const file of maps) {
+        const content = fs.readFileSync(file, 'utf-8');
+
+        fs.writeFileSync(file, content.replace(/\.\.\/src/g, 'src'));
+    }
+
+    console.log(`✅ Fixed source paths in ${maps.length} source map(s)`);
+}
+
+function replaceConstants(constants) {
+    for (const [name, value] of Object.entries(constants)) {
+        if (typeof value !== 'string' || value === '') {
+            throw new Error(`The constant "${name}" resolved to an empty value.`);
+        }
+    }
+
+    const files = findFiles(BUILD_DIR, /^constants\./);
+
+    if (files.length === 0) {
+        throw new Error('No constants file found in the build directory.');
+    }
+
+    for (const file of files) {
+        const content = fs.readFileSync(file, 'utf-8');
+
+        fs.writeFileSync(
+            file,
+            content.replace(PLACEHOLDER_PATTERN, (placeholder, name) => constants[name] ?? placeholder),
+        );
+    }
+
+    console.log(`✅ Replaced constants in ${files.length} file(s)`);
+}
+
+function checkPlaceholders() {
+    const unresolved = [];
+
+    for (const file of findFiles(BUILD_DIR, TEXT_FILE_PATTERN)) {
+        const matches = fs.readFileSync(file, 'utf-8').matchAll(PLACEHOLDER_PATTERN);
+
+        for (const [placeholder] of matches) {
+            unresolved.push(`${path.relative(BUILD_DIR, file)}: ${placeholder}`);
+        }
+    }
+
+    if (unresolved.length > 0) {
+        throw new Error(`Unresolved placeholders found:\n${unresolved.join('\n')}`);
+    }
+
+    console.log('✅ No unresolved placeholders left');
+}
+
+function prepareRelease() {
+    const version = getVersion();
+
+    copyRootFiles();
+    updateVersion(version);
+    fixSourceMaps();
+    replaceConstants(getConstants(version));
+    checkPlaceholders();
+}
+
+prepareRelease();

--- a/release-config.mjs
+++ b/release-config.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import {pathToFileURL} from 'url';
+
+const CDN_ORIGIN = 'https://cdn.croct.io';
+const PLAYGROUND_ORIGIN = 'https://play.croct.com';
+
+/**
+ * The environment variable that exposes each constant to the workflows.
+ */
+const VARIABLES = {
+    cdnUrl: 'CDN_URL',
+    playgroundOrigin: 'PLAYGROUND_ORIGIN',
+    playgroundConnectUrl: 'PLAYGROUND_CONNECT_URL',
+    previewWidgetOrigin: 'PREVIEW_WIDGET_ORIGIN',
+    previewWidgetUrl: 'PREVIEW_WIDGET_URL',
+};
+
+export function getVersion() {
+    const version = process.argv[2] ?? process.env.GITHUB_REF_NAME;
+
+    if (version === undefined || version === '') {
+        throw new Error('The version is missing. Pass it as an argument or set GITHUB_REF_NAME.');
+    }
+
+    return version;
+}
+
+export function getWidgetPath(version) {
+    return `js/v1/lib/plug/widget-${version}.html`;
+}
+
+/**
+ * Resolves the values for the `<@placeholder@>` markers declared in `src/constants.ts`.
+ */
+export function getConstants(version) {
+    return {
+        cdnUrl: `${CDN_ORIGIN}/js/v1/lib/plug.js`,
+        playgroundOrigin: PLAYGROUND_ORIGIN,
+        playgroundConnectUrl: `${PLAYGROUND_ORIGIN}/connect.html`,
+        previewWidgetOrigin: CDN_ORIGIN,
+        previewWidgetUrl: `${CDN_ORIGIN}/${getWidgetPath(version)}`,
+    };
+}
+
+function printVariables() {
+    const version = getVersion();
+    const constants = getConstants(version);
+
+    for (const [name, variable] of Object.entries(VARIABLES)) {
+        console.log(`${variable}=${constants[name]}`);
+    }
+
+    console.log(`PREVIEW_WIDGET_PATH=${getWidgetPath(version)}`);
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    printVariables();
+}


### PR DESCRIPTION
## Problem

`@croct/plug@0.24.0` is published with every constant empty ([unpkg](https://unpkg.com/@croct/plug@0.24.0/constants.js)):

```js
const CDN_URL = "";
const PLAYGROUND_ORIGIN = "";
const PLAYGROUND_CONNECT_URL = "";
const PREVIEW_WIDGET_ORIGIN = "";
const PREVIEW_WIDGET_URL = "";
```

Reported by a user on `@croct/plug-next@0.11.0`. Since `PREVIEW_WIDGET_URL` is empty, the iframe `src` built in `src/plugins/preview/index.ts:102` becomes a relative URL, so the page frames itself instead of the CDN and gets blocked by the host's own `frame-ancestors`. The widget never renders. The empty `PREVIEW_WIDGET_ORIGIN` independently breaks the `postMessage` origin check in `src/plugins/preview/index.ts:128`, so fixing only the URL would not be enough.

The empty `CDN_URL` also silently disables app ID auto-detection: `detectAppId()` in `src/plug.ts:106` queries `script[src^='']`, which never matches.

## Cause

`#373` moved the publish to a reusable workflow and passed the substitution commands as the `prepare-script` input. A caller's workflow-level `env` block is **not** propagated to a called reusable workflow, and `publish-public-npm-package.yml` defines no `env` of its own, so `${CDN_URL}` and the rest were unset in that runner. Actions runs `bash -eo pipefail` without `-u`, so the unset variables expanded to empty strings and `sed` happily replaced each `<@placeholder@>` with nothing. The publish succeeded.

That also explains why only the npm package is affected:

- `$GITHUB_REF_NAME` is a runner default variable, so the version was set correctly.
- The `cdn` and `preview-widget` jobs are ordinary jobs in this workflow, so their variables did resolve — `widget-0.24.0.html` is on the CDN and returns 200.

Note that `${{ env.X }}` is not a workaround either: the `env` context is unavailable in `jobs.<job_id>.with.<input>`.

## Fix

Move the prepare step into `prepare-release.mjs`, so the values live in the repository instead of in workflow environment variables, and **fail the release if any placeholder or empty constant survives** — the check that would have caught this before publishing. `release-config.mjs` holds the values, and the bundle and widget jobs derive their variables from it, so there is a single source of truth rather than a second copy that can drift.

Also in this PR:

- **`deploy-preview.yaml`** substituted `<@version@>`, `<@baseEndpointUrl@>` and `<@maxQueryLength@>`, none of which exist in this package — they were copy-pasted from the SDK. PR previews have therefore always shipped literal `<@cdnUrl@>` placeholders, since well before `#373`. The preview now pins constants to the latest release tag, so `PREVIEW_WIDGET_URL` points at a widget that exists.
- The `preview-widget` job cached `path: node_modules` keyed on the root lockfile while running `npm ci` in `preview/`, using the same cache key as the `cdn` job. A cache hit from `cdn` would make it skip installing the widget dependencies and fail the build. Now matches the pattern already used in `validate-preview.yaml`.

## Verification

Each path was run locally:

- **Release** — output is byte-identical to what 0.23.0 published, with the version swapped.
- **PR preview** — resolves to `widget-0.23.0.html` (latest tag at the time of testing).
- **CDN bundle** — rollup still inlines the correct values into `plug.min.js`.
- **Guards** — a stray placeholder and a missing version both exit `1`.

## Out of scope

`@croct/sdk@0.22.0` ships `MAX_QUERY_LENGTH = parseInt("<@maxQueryLength@>", 10)` → `NaN` (`BASE_ENDPOINT_URL` and `VERSION` are substituted, only that one is missed). Same bug class in `sdk-js`, and it leaks into the CDN `plug.min.js`, which bundles the SDK. The placeholder check here is deliberately scoped to the build output and not the bundle, so releases are not blocked on a dependency's defect.

## Follow-up

npm does not allow republishing `0.24.0`, so this needs a `0.24.1` tag to reach users.
