### PR TITLE
Remove leftover playground constants and bump the SDK

### DIFF
--- a/.github/workflows/deploy-release.yaml
+++ b/.github/workflows/deploy-release.yaml
@@ -47,8 +47,6 @@ jobs:
         run: |-
           rm -rf build
           npm run bundle -- --config-cdn-url=${CDN_URL} \
-              --config-playground-origin=${PLAYGROUND_ORIGIN} \
-              --config-playground-connect-url=${PLAYGROUND_CONNECT_URL} \
               --config-preview-widget-origin=${PREVIEW_WIDGET_ORIGIN} \
               --config-preview-widget-url=${PREVIEW_WIDGET_URL}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@croct/content": "^1.1.0",
         "@croct/json": "^2.1.0",
-        "@croct/sdk": "^0.22.0",
+        "@croct/sdk": "^0.22.4",
         "tslib": "^2.7.0"
       },
       "devDependencies": {
@@ -667,9 +667,9 @@
       }
     },
     "node_modules/@croct/sdk": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@croct/sdk/-/sdk-0.22.0.tgz",
-      "integrity": "sha512-pmcTboXZVrqSk41BgB7S7lz16HdTWRi5AcrPLZIkLQ3EkUvCrXIhIt8ZkoBTq2R9H2wJ48UWbAUHYweUvR2wiA==",
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/@croct/sdk/-/sdk-0.22.4.tgz",
+      "integrity": "sha512-X/Hr0O/FhPPQbpeH+jVWh3Z6dQDCC/2Vyc1g9hipq6SZ4jsy0ZZcFM2OAciLzBrUYhpSudRFufmSPxcz0H447g==",
       "license": "MIT",
       "dependencies": {
         "@croct/content-model": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@croct/content": "^1.1.0",
     "@croct/json": "^2.1.0",
-    "@croct/sdk": "^0.22.0",
+    "@croct/sdk": "^0.22.4",
     "tslib": "^2.7.0"
   },
   "devDependencies": {

--- a/release-config.mjs
+++ b/release-config.mjs
@@ -2,15 +2,12 @@
 import {pathToFileURL} from 'url';
 
 const CDN_ORIGIN = 'https://cdn.croct.io';
-const PLAYGROUND_ORIGIN = 'https://play.croct.com';
 
 /**
  * The environment variable that exposes each constant to the workflows.
  */
 const VARIABLES = {
     cdnUrl: 'CDN_URL',
-    playgroundOrigin: 'PLAYGROUND_ORIGIN',
-    playgroundConnectUrl: 'PLAYGROUND_CONNECT_URL',
     previewWidgetOrigin: 'PREVIEW_WIDGET_ORIGIN',
     previewWidgetUrl: 'PREVIEW_WIDGET_URL',
 };
@@ -35,8 +32,6 @@ export function getWidgetPath(version) {
 export function getConstants(version) {
     return {
         cdnUrl: `${CDN_ORIGIN}/js/v1/lib/plug.js`,
-        playgroundOrigin: PLAYGROUND_ORIGIN,
-        playgroundConnectUrl: `${PLAYGROUND_ORIGIN}/connect.html`,
         previewWidgetOrigin: CDN_ORIGIN,
         previewWidgetUrl: `${CDN_ORIGIN}/${getWidgetPath(version)}`,
     };

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -14,14 +14,6 @@ export default args => {
         throw new Error('The argument "config-cdn-url" is missing.');
     }
 
-    if (args['config-playground-origin'] === undefined) {
-        throw new Error('The argument "config-playground-origin" is missing.');
-    }
-
-    if (args['config-playground-connect-url'] === undefined) {
-        throw new Error('The argument "config-playground-connect-url" is missing.');
-    }
-
     if (args['config-preview-widget-origin'] === undefined) {
         throw new Error('The argument "config-preview-widget-origin" is missing.');
     }
@@ -50,8 +42,6 @@ export default args => {
                     preventAssignment: true,
                     delimiters: ['<@', '@>'],
                     cdnUrl: args['config-cdn-url'],
-                    playgroundOrigin: args['config-playground-origin'],
-                    playgroundConnectUrl: args['config-playground-connect-url'],
                     previewWidgetOrigin: args['config-preview-widget-origin'],
                     previewWidgetUrl: args['config-preview-widget-url'],
                 }),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,3 @@
 export const CDN_URL = '<@cdnUrl@>';
-export const PLAYGROUND_ORIGIN = '<@playgroundOrigin@>';
-export const PLAYGROUND_CONNECT_URL = '<@playgroundConnectUrl@>';
 export const PREVIEW_WIDGET_ORIGIN = '<@previewWidgetOrigin@>';
 export const PREVIEW_WIDGET_URL = '<@previewWidgetUrl@>';


### PR DESCRIPTION
## Summary

Two related pieces of constants cleanup found while verifying the 0.24.1 release.

## 1. Remove the leftover playground constants

`PLAYGROUND_ORIGIN` and `PLAYGROUND_CONNECT_URL` have been dead since the playground plugin was removed in #350 — the declarations in `src/constants.ts` were the only references left. They were absent from the CDN bundle because the bundler tree-shakes them, but were still being resolved and shipped in the npm package.

`grep` for `PLAYGROUND_ORIGIN`, `PLAYGROUND_CONNECT_URL` and `plug/constants` across `plug-js`, `plug-react`, `plug-next` and `application-ui-js` returns only the two declarations being removed here.

Removed from the four places that had to stay in sync:

- `src/constants.ts` — the two exports
- `release-config.mjs` — the values and their workflow variables
- `rollup.config.mjs` — the required arguments and their `replace` entries
- `.github/workflows/deploy-release.yaml` — the two `--config-playground-*` bundle arguments

All four had to change together: `rollup.config.mjs` throws when a `--config-*` argument is missing, so leaving the workflow untouched would have broken the CDN bundle.

## 2. Bump `@croct/sdk` to 0.22.4

Every SDK release up to 0.22.3 published `MAX_QUERY_LENGTH` as `parseInt("<@maxQueryLength@>", 10)`, which is `NaN`. Since `length > NaN` is always false, the query length guard in `Evaluator.evaluate()` never rejected, so over-long queries were sent to the server instead of failing locally. Fixed in croct-tech/sdk-js#528 and released as 0.22.4.

The range is raised to `^0.22.4` rather than left at `^0.22.0`, so the fix is guaranteed rather than dependent on when the dependency happens to be resolved. It also removes the last `<@maxQueryLength@>` placeholder from the CDN bundle, which inlines the SDK:

```
before: parseInt("<@maxQueryLength@>",10)   // NaN
after:  parseInt("500",10)
```

The lockfile diff touches `@croct/sdk` only.

## Checks

- `npm run build` + `node prepare-release.mjs` produce the expected constants, with no placeholders left.
- The CDN bundle builds with the reduced argument set, inlines the correct `CDN_URL` and widget URL, and now contains no `<@…@>` placeholders at all.
- `tsc --noEmit`, ESLint, and the test suite (328 tests) all pass.

## Note

`constants` is reachable through the `./*` exports map, so this drops two public exports. They were build-time placeholders for a feature that no longer exists rather than documented API, but it warrants a minor bump rather than a patch.
